### PR TITLE
chore: Prisma 마이그레이션 및 시딩 코드 수정

### DIFF
--- a/src/prisma/migrations/20250821041036_/migration.sql
+++ b/src/prisma/migrations/20250821041036_/migration.sql
@@ -1,0 +1,111 @@
+CREATE EXTENSION IF NOT EXISTS citext;
+
+/*
+  Warnings:
+
+  - You are about to drop the column `imageUrl` on the `SocialAccount` table. All the data in the column will be lost.
+  - You are about to drop the column `done` on the `Subtask` table. All the data in the column will be lost.
+  - You are about to drop the column `dueDate` on the `Task` table. All the data in the column will be lost.
+  - You are about to drop the column `tags` on the `Task` table. All the data in the column will be lost.
+  - You are about to drop the column `imageUrl` on the `User` table. All the data in the column will be lost.
+  - You are about to drop the `File` table. If the table is not empty, all the data it contains will be lost.
+  - Added the required column `updatedAt` to the `Subtask` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `endDate` to the `Task` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `startDate` to the `Task` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- CreateEnum
+CREATE TYPE "public"."InvitationStatus" AS ENUM ('PENDING', 'ACCEPTED', 'REJECTED');
+
+-- DropForeignKey
+ALTER TABLE "public"."File" DROP CONSTRAINT "File_taskId_fkey";
+
+-- DropIndex
+DROP INDEX "public"."ProjectMember_userId_idx";
+
+-- DropIndex
+DROP INDEX "public"."Task_dueDate_idx";
+
+-- AlterTable
+ALTER TABLE "public"."Invitation" ADD COLUMN     "status" "public"."InvitationStatus" NOT NULL DEFAULT 'PENDING';
+
+-- AlterTable
+ALTER TABLE "public"."SocialAccount" DROP COLUMN "imageUrl",
+ADD COLUMN     "profileImage" TEXT;
+
+-- AlterTable
+ALTER TABLE "public"."Subtask" DROP COLUMN "done",
+ADD COLUMN     "status" "public"."TaskStatus" NOT NULL DEFAULT 'TODO',
+ADD COLUMN     "updatedAt" TIMESTAMP(3) NOT NULL;
+
+-- AlterTable
+ALTER TABLE "public"."Task" DROP COLUMN "dueDate",
+DROP COLUMN "tags",
+ADD COLUMN     "endDate" TIMESTAMP(3) NOT NULL,
+ADD COLUMN     "startDate" TIMESTAMP(3) NOT NULL;
+
+-- AlterTable
+ALTER TABLE "public"."User" DROP COLUMN "imageUrl",
+ADD COLUMN     "deletedAt" TIMESTAMP(3),
+ADD COLUMN     "profileImage" TEXT,
+ADD COLUMN     "refreshTokenVersion" INTEGER NOT NULL DEFAULT 0,
+ALTER COLUMN "email" SET DATA TYPE CITEXT;
+
+-- DropTable
+DROP TABLE "public"."File";
+
+-- CreateTable
+CREATE TABLE "public"."Attachments" (
+    "id" SERIAL NOT NULL,
+    "taskId" INTEGER NOT NULL,
+    "originalName" TEXT NOT NULL,
+    "storedName" TEXT NOT NULL,
+    "relPath" TEXT NOT NULL,
+    "mimeType" TEXT,
+    "size" INTEGER,
+    "ext" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Attachments_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."Tag" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Tag_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."TaskTag" (
+    "taskId" INTEGER NOT NULL,
+    "tagId" INTEGER NOT NULL,
+
+    CONSTRAINT "TaskTag_pkey" PRIMARY KEY ("taskId","tagId")
+);
+
+-- CreateIndex
+CREATE INDEX "Attachments_taskId_idx" ON "public"."Attachments"("taskId");
+
+-- CreateIndex
+CREATE INDEX "Attachments_storedName_idx" ON "public"."Attachments"("storedName");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Tag_name_key" ON "public"."Tag"("name");
+
+-- CreateIndex
+CREATE INDEX "Project_name_idx" ON "public"."Project"("name");
+
+-- CreateIndex
+CREATE INDEX "ProjectMember_projectId_idx" ON "public"."ProjectMember"("projectId");
+
+-- AddForeignKey
+ALTER TABLE "public"."Attachments" ADD CONSTRAINT "Attachments_taskId_fkey" FOREIGN KEY ("taskId") REFERENCES "public"."Task"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."TaskTag" ADD CONSTRAINT "TaskTag_taskId_fkey" FOREIGN KEY ("taskId") REFERENCES "public"."Task"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."TaskTag" ADD CONSTRAINT "TaskTag_tagId_fkey" FOREIGN KEY ("tagId") REFERENCES "public"."Tag"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/src/prisma/seed.ts
+++ b/src/prisma/seed.ts
@@ -1,43 +1,188 @@
 import prisma from '#prisma/prisma';
 import { ProjectRole, TaskStatus } from '@prisma/client';
 
-const main = async (): Promise<void> => {
-  const alice = await prisma.user.upsert({
-    where: { email: 'user1@test.com' },
+const DAYS = (n: number) => n * 24 * 60 * 60 * 1000;
+
+const ensureUser = async (params: {
+  email: string;
+  name: string;
+  password?: string | null;
+  profileImage?: string | null;
+}) => {
+  const { email, name, password = 'hashed', profileImage = null } = params;
+  return prisma.user.upsert({
+    where: { email },
+    update: { name, profileImage },
+    create: { email, name, password, profileImage },
+  });
+};
+
+const ensureTag = async (name: string) => {
+  return prisma.tag.upsert({
+    where: { name },
     update: {},
+    create: { name },
+  });
+};
+
+const main = async (): Promise<void> => {
+  // user
+  const alice = await ensureUser({
+    email: 'user1@test.com',
+    name: 'User1',
+    password: 'hashed', // TODO: bcrypt 해시 적용
+  });
+
+  const bob = await ensureUser({
+    email: 'user2@test.com',
+    name: 'User2',
+    password: 'hashed',
+  });
+
+  // Social
+  await prisma.socialAccount.upsert({
+    where: { provider_providerUid: { provider: 'GOOGLE', providerUid: 'google-sub-001' } },
+    update: { email: 'user1@test.com', displayName: 'User1 Google' },
     create: {
+      userId: alice.id,
+      provider: 'GOOGLE',
+      providerUid: 'google-sub-001',
       email: 'user1@test.com',
-      name: 'User1',
-      password: 'hashed', // TODO: bcrypt 해시 적용 예정
+      displayName: 'User1 Google',
     },
   });
 
-  await prisma.$transaction(async (tx) => {
-    const project = await tx.project.create({
+  // Project / Members
+  const project =
+    (await prisma.project.findFirst({ where: { name: 'Demo', ownerId: alice.id } })) ??
+    (await prisma.project.create({
       data: {
         name: 'Demo',
         description: 'Demo project',
         ownerId: alice.id,
       },
-    });
+    }));
 
-    await tx.projectMember.create({
-      data: {
-        projectId: project.id,
-        userId: alice.id,
-        role: ProjectRole.OWNER,
-      },
-    });
+  await prisma.projectMember.upsert({
+    where: { projectId_userId: { projectId: project.id, userId: alice.id } },
+    update: { role: ProjectRole.OWNER },
+    create: { projectId: project.id, userId: alice.id, role: ProjectRole.OWNER },
+  });
 
-    await tx.task.create({
-      data: {
-        projectId: project.id,
-        assigneeId: alice.id,
-        title: '첫 할 일',
-        status: TaskStatus.TODO,
-        tags: [],
-      },
+  await prisma.projectMember.upsert({
+    where: { projectId_userId: { projectId: project.id, userId: bob.id } },
+    update: { role: ProjectRole.MEMBER },
+    create: { projectId: project.id, userId: bob.id, role: ProjectRole.MEMBER },
+  });
+
+  // Tags
+  const [urgent, backend, design] = await Promise.all([ensureTag('urgent'), ensureTag('backend'), ensureTag('design')]);
+
+  // Task / Subtask / Comment / Tag link
+  await prisma.$transaction(async (tx) => {
+    const now = new Date();
+    const nextWeek = new Date(now.getTime() + DAYS(7));
+
+    const task1 =
+      (await tx.task.findFirst({ where: { projectId: project.id, title: '프로젝트 초기 세팅' } })) ??
+      (await tx.task.create({
+        data: {
+          projectId: project.id,
+          assigneeId: alice.id,
+          title: '프로젝트 초기 세팅',
+          description: '리포지토리 구조, TS/ESLint/Prettier, Prisma 설정',
+          status: TaskStatus.IN_PROGRESS,
+          startDate: now,
+          endDate: nextWeek,
+        },
+      }));
+
+    const task2 =
+      (await tx.task.findFirst({ where: { projectId: project.id, title: 'API 설계 초안' } })) ??
+      (await tx.task.create({
+        data: {
+          projectId: project.id,
+          assigneeId: bob.id,
+          title: 'API 설계 초안',
+          description: '인증/프로젝트/태스크/코멘트 엔드포인트 초안',
+          status: TaskStatus.TODO,
+          startDate: now,
+          endDate: new Date(now.getTime() + DAYS(10)),
+        },
+      }));
+
+    // Subtask
+    const ensureSubtask = async (taskId: number, title: string, status: TaskStatus) => {
+      const exists = await tx.subtask.findFirst({ where: { taskId, title } });
+      if (!exists) {
+        await tx.subtask.create({ data: { taskId, title, status } });
+      }
+    };
+
+    await ensureSubtask(task1.id, 'Prisma 스키마 정리', TaskStatus.IN_PROGRESS);
+    await ensureSubtask(task1.id, 'ESLint/Prettier 구성', TaskStatus.TODO);
+
+    // Comment
+    const commentExists = await tx.comment.findFirst({
+      where: { taskId: task1.id, authorId: alice.id, content: { startsWith: '[초기화]' } },
     });
+    if (!commentExists) {
+      await tx.comment.create({
+        data: {
+          taskId: task1.id,
+          authorId: alice.id,
+          content: '[초기화] 기본 규칙 및 디렉토리 구조 제안',
+        },
+      });
+    }
+
+    // Tag links
+    const ensureTaskTag = (taskId: number, tagId: number) =>
+      tx.taskTag.upsert({
+        where: { taskId_tagId: { taskId, tagId } },
+        update: {},
+        create: { taskId, tagId },
+      });
+
+    await Promise.all([
+      ensureTaskTag(task1.id, urgent.id),
+      ensureTaskTag(task1.id, backend.id),
+      ensureTaskTag(task2.id, design.id),
+    ]);
+
+    // Attachments
+    const attach1 = await tx.attachments.findFirst({
+      where: { taskId: task1.id, storedName: 'setup-guide.md' },
+    });
+    if (!attach1) {
+      await tx.attachments.create({
+        data: {
+          taskId: task1.id,
+          originalName: 'setup-guide.md',
+          storedName: 'setup-guide.md',
+          relPath: 'docs/setup-guide.md',
+          mimeType: 'text/markdown',
+          size: 2048,
+          ext: 'md',
+        },
+      });
+    }
+
+    // Invitation
+    const invExists = await tx.invitation.findFirst({
+      where: { projectId: project.id, email: 'user2@test.com' },
+    });
+    if (!invExists) {
+      await tx.invitation.create({
+        data: {
+          projectId: project.id,
+          email: 'user2@test.com',
+          token: 'demo-invite-token',
+          createdBy: alice.id,
+          expiresAt: new Date(now.getTime() + DAYS(3)),
+        },
+      });
+    }
   });
 
   console.log('🌱 Seed Complete');


### PR DESCRIPTION
## 주요 변경 사항
- citext 확장 미설치로 실패했던 마이그레이션을 정리하고 재생성했습니다.  
- 개발 환경에서 `npx prisma migrate reset`을 통해 마이그레이션을 정상적으로 재적용했습니다.  
- 시딩 코드를 최신 스키마(User, Project, Task, Subtask, Comment, Tag 등)에 맞춰 전면 수정했습니다.  
  - 기본 유저/프로젝트/멤버/태그/작업/코멘트/첨부/초대까지 생성되도록 보강  

## 참고 사항
- 프로덕션 환경에서는 `CREATE EXTENSION citext;` 권한이 필요할 수 있습니다.  
- 개발 DB에서는 `npx prisma migrate reset` 실행 후 시드를 재적용해야 합니다.
