### PR TITLE
forwardZodError 유틸 함수화 및 Prettier 설정 변경

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,4 @@
 {
   "editor.formatOnSave": true,
-  "editor.defaultFormatter": "esbenp.prettier-vscode",
-  "[typescript]": {
-    "editor.defaultFormatter": "vscode.typescript-language-features"
-  }
+  "editor.defaultFormatter": "esbenp.prettier-vscode"
 }

--- a/src/utils/zod.ts
+++ b/src/utils/zod.ts
@@ -1,0 +1,40 @@
+import { ZodError } from 'zod';
+import type { NextFunction } from 'express';
+import ApiError from '#errors/ApiError';
+
+/**
+ * 주어진 에러가 ZodError라면 에러 메시지를 포맷팅하여
+ * ApiError(400)로 감싸 next()로 전달합니다.
+ * ZodError가 아니라면 원본 에러를 그대로 next()로 전달합니다.
+ *
+ * @param {unknown} err - try/catch 블록에서 잡힌 에러 객체
+ * @param {string} context - 에러 메시지에 포함할 컨텍스트
+ * @param {NextFunction} next - Express의 next 함수
+ *
+ *
+ * import { forwardZodError } from '#utils/zod';
+ *
+ * export const validateProductCreate: RequestHandler = (req, _res, next) =>
+ *  const parsedBody = {
+ *    ...req, body,
+ *    price: req.body.price !== undefined ? Number(req.body.price) : undefined;
+ *  };
+ *
+ *  try {
+ *    productCreateSchema.parse(parsedBody);
+ *    next();
+ *  } catch (err) {
+ *    return forwardZodError(err, '상품 등록', next);\
+ *  }
+ * };
+ *
+ */
+const forwardZodError = (err: unknown, context: string, next: NextFunction) => {
+  if (err instanceof ZodError) {
+    const messages = err.issues.map((e) => `${e.path.join('.')}: ${e.message}`).join(', ');
+    return next(new ApiError(400, `${context} 유효성 검사 실패: ${messages}`));
+  }
+  return next(err as Error);
+};
+
+export default forwardZodError;


### PR DESCRIPTION
## 주요 변경 사항
- Zod 에러 처리 로직을 `forwardZodError` 유틸 함수로 분리했습니다.
- .vscode의 prettier 설정을 활성화 시켰습니다.

## 참고 사항
- 다른 validation 미들웨어에서도 동일한 유틸 적용이 가능합니다.