### PR TITLE
Feature/project: 프로젝트 멤버 조회, 초대 취소 기능 추가

### DIFF
--- a/src/modules/invitations/dto/invitations.Dto.ts
+++ b/src/modules/invitations/dto/invitations.Dto.ts
@@ -3,13 +3,13 @@ import { z } from 'zod';
 export const createMemberSchema = z.object({
   projectId: z.number().min(1),
   userId: z.number().min(1),
-  role: z.enum(['OWNER', 'MEMBER']).default('MEMBER')
+  role: z.enum(['OWNER', 'MEMBER', 'INVITED']).default('MEMBER')
 })
 
 export const acceptInvitationSchema = z.object({
   projectId: z.number().min(1),
   userId: z.number().min(1),
-  role: z.enum(['OWNER', 'MEMBER']).default('MEMBER')
+  role: z.enum(['OWNER', 'MEMBER', 'INVITED']).default('MEMBER')
 })
 
 export type CreateMemberDto = z.infer<typeof createMemberSchema>;

--- a/src/modules/invitations/invitaions.router.ts
+++ b/src/modules/invitations/invitaions.router.ts
@@ -1,5 +1,5 @@
 import { Router } from 'express';
-import invitationController from './invitations.controller'
+import invitationController from '#modules/invitations/invitations.controller'
 import { requireAuth } from '#middlewares/requireAuth';
 
 const router = Router();

--- a/src/modules/invitations/invitaions.router.ts
+++ b/src/modules/invitations/invitaions.router.ts
@@ -4,8 +4,9 @@ import { requireAuth } from '#middlewares/requireAuth';
 
 const router = Router();
 
-router
-  .route('/:invitationId/accept')
-  .post(requireAuth, invitationController.acceptInvitation)
+router.route('/:invitationId').delete(requireAuth, invitationController.deleteInvitation);
+
+router.route('/:invitationId/accept').post(requireAuth, invitationController.acceptInvitation)
+
 
 export default router;

--- a/src/modules/invitations/invitations.controller.ts
+++ b/src/modules/invitations/invitations.controller.ts
@@ -1,7 +1,6 @@
-import jwt from 'jsonwebtoken';
 import type { RequestHandler } from 'express';
-import type { AcceptInvitationDto, CreateMemberDto } from './dto/invitations.Dto';
-import invitationService from './invitations.service';
+import type { AcceptInvitationDto, CreateMemberDto } from '#modules/invitations/dto/invitations.Dto';
+import invitationService from '#modules/invitations/invitations.service';
 
 /**
  * @function acceptInvitation

--- a/src/modules/invitations/invitations.controller.ts
+++ b/src/modules/invitations/invitations.controller.ts
@@ -29,6 +29,14 @@ export const acceptInvitation: RequestHandler = async (req, res) => {
   res.sendStatus(200);
 }
 
+export const deleteInvitation: RequestHandler = async (req, res) => {
+  const userId = req.user.id;
+  const invitationId = Number(req.params.invitationId);
+  await invitationService.removeInvitation(invitationId, userId);
+  res.sendStatus(204);
+}
+
 export default {
-  acceptInvitation
+  acceptInvitation,
+  deleteInvitation
 }

--- a/src/modules/invitations/invitations.repo.ts
+++ b/src/modules/invitations/invitations.repo.ts
@@ -1,7 +1,7 @@
 import prisma from '#prisma/prisma';
 import type { CreateMemberDto } from '#modules/invitations/dto/invitations.Dto';
 
-export const findInvitationById = async (id: number) => {
+export const findById = async (id: number) => {
   return await prisma.invitation.findUnique({
     where: { id }
   })
@@ -24,14 +24,25 @@ export const update = async (id: number) => {
   })
 }
 
-export const remove = async (invitationId: number) => {
-  return await prisma.invitation.delete({
-    where: { id: invitationId }
+export const remove = async (invitation: { id: number; projectId: number; email: string }) => {
+  await prisma.$transaction(async (tx) => {
+    // 프로젝트 멤버 데이터 삭제
+    await tx.projectMember.deleteMany({
+      where: {
+        projectId: invitation.projectId,
+        role: 'INVITED',
+        user: { email: invitation.email }
+      }
+    })
+    // 초대 데이터 삭제
+    await tx.invitation.deleteMany({
+      where: { id: invitation.id }
+    });
   });
 }
 
 export default {
-  findInvitationById,
+  findById,
   createMember,
   update,
   remove

--- a/src/modules/invitations/invitations.repo.ts
+++ b/src/modules/invitations/invitations.repo.ts
@@ -1,5 +1,5 @@
 import prisma from '#prisma/prisma';
-import type { CreateMemberDto } from './dto/invitations.Dto';
+import type { CreateMemberDto } from '#modules/invitations/dto/invitations.Dto';
 
 export const findInvitationById = async (id: number) => {
   return await prisma.invitation.findUnique({
@@ -17,6 +17,13 @@ export const createMember = async (data: CreateMemberDto) => {
   })
 }
 
+export const update = async (id: number) => {
+  await prisma.invitation.update({
+    where: { id },
+    data: { status: 'accepted' }
+  })
+}
+
 export const remove = async (invitationId: number) => {
   return await prisma.invitation.delete({
     where: { id: invitationId }
@@ -26,5 +33,6 @@ export const remove = async (invitationId: number) => {
 export default {
   findInvitationById,
   createMember,
+  update,
   remove
 }

--- a/src/modules/invitations/invitations.service.ts
+++ b/src/modules/invitations/invitations.service.ts
@@ -1,11 +1,11 @@
 import ApiError from "#errors/ApiError";
-import type { AcceptInvitationDto } from "./dto/invitations.Dto";
-import invitationRepo from "./invitations.repo";
+import type { AcceptInvitationDto } from "#modules/invitations/dto/invitations.Dto";
+import invitationRepo from "#modules/invitations/invitations.repo";
 
 
 const acceptInvitation = async (acceptInvitationDto: AcceptInvitationDto, invitationId: number) => {
   await invitationRepo.createMember(acceptInvitationDto);
-  await invitationRepo.remove(invitationId);
+  await invitationRepo.update(invitationId);
 };
 
 const checkInvitation = async (invitationId: number, acceptedToken: string) => {

--- a/src/modules/invitations/invitations.service.ts
+++ b/src/modules/invitations/invitations.service.ts
@@ -19,6 +19,7 @@ const checkInvitation = async (invitationId: number, acceptedToken: string) => {
   if (!invitation) throw ApiError.notFound("잘못된 초대입니다.");
   if (invitation.token !== acceptedToken) throw ApiError.notFound("잘못된 초대입니다.");
   if (invitation.expiresAt! < new Date()) throw ApiError.badRequest("만료된 초대입니다.");
+  if (invitation.status === 'accepted') throw ApiError.badRequest("이미 수락된 초대입니다.");
 
   return invitation.projectId;
 }
@@ -26,7 +27,9 @@ const checkInvitation = async (invitationId: number, acceptedToken: string) => {
 const removeInvitation = async (invitationId: number, userId: number) => {
   const invitation = await invitationRepo.findById(invitationId);
   if (!invitation) throw ApiError.notFound("초대 정보를 찾을 수 없습니다.");
-  checkRole(userId, invitation.projectId);
+  if (invitation.status === 'accepted') throw ApiError.badRequest("이미 수락된 초대입니다.");
+
+  await checkRole(userId, invitation.projectId);
   await invitationRepo.remove(invitation);
 };
 

--- a/src/modules/invitations/invitations.service.ts
+++ b/src/modules/invitations/invitations.service.ts
@@ -1,15 +1,21 @@
 import ApiError from "#errors/ApiError";
 import type { AcceptInvitationDto } from "#modules/invitations/dto/invitations.Dto";
 import invitationRepo from "#modules/invitations/invitations.repo";
-
+import projectRepo from "#modules/projects/projects.repo";
 
 const acceptInvitation = async (acceptInvitationDto: AcceptInvitationDto, invitationId: number) => {
   await invitationRepo.createMember(acceptInvitationDto);
   await invitationRepo.update(invitationId);
 };
 
+const checkRole = async (userId: number, projectId: number) => {
+  const member = await projectRepo.findMemberById({ projectId, userId });
+  if (!member) throw ApiError.notFound('프로젝트 멤버가 아닙니다.');
+  if (member.role !== 'OWNER') throw ApiError.forbidden('권한이 없습니다.');
+}
+
 const checkInvitation = async (invitationId: number, acceptedToken: string) => {
-  const invitation = await invitationRepo.findInvitationById(invitationId);
+  const invitation = await invitationRepo.findById(invitationId);
   if (!invitation) throw ApiError.notFound("잘못된 초대입니다.");
   if (invitation.token !== acceptedToken) throw ApiError.notFound("잘못된 초대입니다.");
   if (invitation.expiresAt! < new Date()) throw ApiError.badRequest("만료된 초대입니다.");
@@ -17,7 +23,15 @@ const checkInvitation = async (invitationId: number, acceptedToken: string) => {
   return invitation.projectId;
 }
 
+const removeInvitation = async (invitationId: number, userId: number) => {
+  const invitation = await invitationRepo.findById(invitationId);
+  if (!invitation) throw ApiError.notFound("초대 정보를 찾을 수 없습니다.");
+  checkRole(userId, invitation.projectId);
+  await invitationRepo.remove(invitation);
+};
+
 export default {
   acceptInvitation,
-  checkInvitation
+  checkInvitation,
+  removeInvitation
 }

--- a/src/modules/projects/dto/me-projects.dto.ts
+++ b/src/modules/projects/dto/me-projects.dto.ts
@@ -4,7 +4,7 @@ export const meProjectQuerySchema = z.object({
   page: z.coerce.number().int().positive().default(1),
   limit: z.coerce.number().int().min(1).max(100).default(5),
   order: z.enum(['asc', 'desc']).default('asc'),
-  order_by: z.enum(['createdAt', 'name']).default('createdAt'),
+  order_by: z.enum(['created_at', 'name']).default('created_at'),
 })
 
 export type MeProjectQueryDto = z.infer<typeof meProjectQuerySchema>;

--- a/src/modules/projects/dto/projects.dto.ts
+++ b/src/modules/projects/dto/projects.dto.ts
@@ -23,6 +23,15 @@ export const updateProjectSchema = z.object({
   description: z.string().max(500).optional()
 });
 
+export type createProjectDto = z.infer<typeof createProjectSchema>;
+export type updateProjectDto = z.infer<typeof updateProjectSchema>;
+
+export const projectMemberQuerySchema = z.object({
+  page: z.coerce.number().int().positive().default(1),
+  limit: z.coerce.number().int().min(1).max(100).default(5),
+})
+export type projectMemberQueryDto = z.infer<typeof projectMemberQuerySchema>;
+
 export const invitationSchema = z.object({
   projectId: z.number().min(1),
   targetEmail: emailWithMX,
@@ -30,8 +39,7 @@ export const invitationSchema = z.object({
   inviter: z.number().min(1).optional()
 });
 
-export type createProjectDto = z.infer<typeof createProjectSchema>;
-export type updateProjectDto = z.infer<typeof updateProjectSchema>;
+
 export type ExcludeMemberDto = {
   projectId: number;
   targetUserId: number;

--- a/src/modules/projects/projects.router.ts
+++ b/src/modules/projects/projects.router.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express';
-import projectController from './projects.controller';
-import validateProject from './projects.validator';
+import projectController from '#modules/projects/projects.controller';
+import validateProject from '#modules/projects/projects.validator';
 import { requireAuth } from '#middlewares/requireAuth';
 import projectTasksController from '#modules/tasks/projects/projectTasks.controller';
 import projectTasksValidator from '#modules/tasks/projects/projectTasks.validator';
@@ -15,6 +15,10 @@ router.route('/').post(
 
 router
   .route('/:projectId')
+  .get(
+    requireAuth,
+    projectController.getProject
+  )
   .patch(
     requireAuth, 
     validateProject.validateUpdateProject,
@@ -26,6 +30,12 @@ router
   )
 
 router.route('/:projectId/invitations').post(requireAuth, projectController.createInvitation);
+
+router.route('/:projectId/users').get(
+  requireAuth,
+  validateProject.validateProjectMemberQuery,
+  projectController.getProjectMembers
+);
 
 router.route('/:projectId/users/:userId').delete(projectController.excludeMember);
 

--- a/src/modules/projects/projects.service.ts
+++ b/src/modules/projects/projects.service.ts
@@ -19,7 +19,7 @@ const formatProject = (project: any) => {
 
 const checkRole = async (userId: number, projectId: number) => {
   const member = await projectRepo.findMemberById({ projectId, userId });
-  if (!member) throw ApiError.notFound('프로젝트 멤버가 아닙니다.');
+  if (!member) throw ApiError.forbidden('프로젝트 멤버가 아닙니다.');
   if (member.role !== 'OWNER') throw ApiError.forbidden('권한이 없습니다.');
 }
 

--- a/src/modules/projects/projects.service.ts
+++ b/src/modules/projects/projects.service.ts
@@ -1,9 +1,9 @@
 import prisma from "#prisma/prisma";
 import ApiError from "#errors/ApiError";
-import projectRepo from './projects.repo';
-import { InvitationDto, ExcludeMemberDto, createProjectDto, updateProjectDto } from './dto/projects.dto';
-import mailUtils from "./utils/mailUtils";
-import { MeProjectQueryDto } from "./dto/me-projects.dto";
+import projectRepo from '#modules/projects/projects.repo';
+import { InvitationDto, ExcludeMemberDto, createProjectDto, updateProjectDto, projectMemberQueryDto } from '#modules/projects/dto/projects.dto';
+import mailUtils from "#modules/projects/utils/mailUtils";
+import { MeProjectQueryDto } from "#modules/projects/dto/me-projects.dto";
 
 const formatProject = (project: any) => {
   return {
@@ -19,13 +19,8 @@ const formatProject = (project: any) => {
 
 const checkRole = async (userId: number, projectId: number) => {
   const member = await projectRepo.findMemberById({ projectId, userId });
-  if (!member) throw ApiError.notFound('사용자를 찾을 수 없습니다.');
+  if (!member) throw ApiError.notFound('프로젝트 멤버가 아닙니다.');
   if (member.role !== 'OWNER') throw ApiError.forbidden('권한이 없습니다.');
-}
-
-const checkMember = async (userId: number, projectId: number) => {
-  const member = await projectRepo.findMemberById({ projectId, userId });
-  if (!member) throw ApiError.forbidden('프로젝트 멤버가 아닙니다.');
 }
 
 const createProject = async (data: createProjectDto, userId: number) => {
@@ -33,20 +28,47 @@ const createProject = async (data: createProjectDto, userId: number) => {
   return formatProject(project);
 }
 
-const getProject = async (projectId: number) => {
-  const project = await projectRepo.findById(projectId);
+const getProject = async (projectId: number, userId: number) => {
+  const project = await projectRepo.findById(projectId, userId);
   if (!project) throw ApiError.notFound('프로젝트를 찾을 수 없습니다.');
+  if (project.members.length === 0) throw ApiError.forbidden('프로젝트 멤버가 아닙니다.');
 
   return formatProject(project);
 }
 
-const updateProject = async (data: updateProjectDto, projectId: number) => {
+const getProjectMembers = async (projectId: number, query: projectMemberQueryDto) => {
+  const { members, total } = await projectRepo.findMembers(projectId, query);
+  if (!members) throw ApiError.notFound('프로젝트를 찾을 수 없습니다.');
+
+  const tempMembers = members.members;
+  const tempInvitations = members.invitations;
+
+  const data = members.members.map((member) => {
+    const invite = members.invitations.find((invitation) => invitation.email === member.user.email);
+    return {
+      id: member.user.id,
+      name: member.user.name,
+      email: member.user.email,
+      profileImage: member.user.profileImage,
+      taskCount: member.user._count.tasks,
+      status: invite?.status,
+      invitationId: invite?.id
+    }
+  })
+
+  return { data, total };
+}
+
+const updateProject = async (data: updateProjectDto, projectId: number, userId: number) => {
+  checkRole(projectId, userId);
   const project = await projectRepo.update(data, projectId);
   return formatProject(project);
 }
 
-const deleteProject = async (projectId: number) => {
+const deleteProject = async (projectId: number, userId: number) => {
+  checkRole(projectId, userId);
   const deleteMailInfo = await projectRepo.findDeleteMailInfo(projectId);
+  if (!deleteMailInfo) throw ApiError.notFound('프로젝트를 찾을 수 없습니다.');
   await projectRepo.remove(projectId);
   
   const mailInfo = {
@@ -63,27 +85,34 @@ const deleteProject = async (projectId: number) => {
 }
 
 const sendInvitation = async (data: InvitationDto) => {
+  checkRole(data.inviter!, data.projectId);
+
   await prisma.$transaction(async (tx) => {
-    const { id } = await projectRepo.createInvitation(data, tx);
-    const mailInfo = {
-      subject: "프로젝트에 초대합니다",
-      html: `
-        <h1> 프로젝트에 초대합니다. </h1>
-        <p>아래 링크를 클릭하여 프로젝트에 참여하세요:</p>
-        <a href="${process.env.FRONT_URL}/invitations/${id}?token=${data.invitationToken}">참여하기</a>
-      `
-    }
-    await mailUtils.sendMail(data.targetEmail, mailInfo);
-  })
+    const targetUserId = await projectRepo.findUserByEmail(data.targetEmail, tx);
+    if (!targetUserId) throw ApiError.notFound('초대할 사용자를 찾을 수 없습니다.');
+    const id = await projectRepo.createInvitation(data, targetUserId.id, tx);
+  });
+  return data.invitationToken;
+  // await prisma.$transaction(async (tx) => {
+  //   const targetUserId = await projectRepo.findUserByEmail(data.targetEmail, tx);
+  //   if (!targetUserId) throw ApiError.notFound('초대할 사용자를 찾을 수 없습니다.');
+  //
+  //   const id = await projectRepo.createInvitation(data, targetUserId.id, tx);
+  //   const mailInfo = {
+  //     subject: "프로젝트에 초대합니다",
+  //     html: `
+  //       <h1> 프로젝트에 초대합니다. </h1>
+  //       <p>아래 링크를 클릭하여 프로젝트에 참여하세요:</p>
+  //       <a href="${process.env.FRONT_URL}/invitations/${id}?token=${data.invitationToken}">참여하기</a>
+  //     `
+  //   }
+  //   await mailUtils.sendMail(data.targetEmail, mailInfo);
+  // })
 }
 
-const excludeMember = async (data: ExcludeMemberDto) => {
+const excludeMember = async (data: ExcludeMemberDto, userId: number) => {
   if(data.targetUserId < 1) throw ApiError.badRequest('유효하지 않은 사용자 ID입니다.');
-
-  const member = await projectRepo.findMemberById({ projectId: data.projectId, userId: data.targetUserId });
-  if(!member) throw ApiError.notFound('프로젝트 멤버가 아닙니다.');
-  if(member.role !== 'OWNER') throw ApiError.forbidden('권한이 없습니다.');
-  
+  checkRole(userId, data.projectId);
   await projectRepo.removeMember(data);
 }
 
@@ -92,13 +121,7 @@ const getMyProjects = async (userId: number, query: MeProjectQueryDto) => {
 
   const formattedProjects = projects.data.map(project => {
     return {
-      id: project.id,
-      name: project.name,
-      description: project.description,
-      memberCount: project._count.members,
-      todoCount: project.tasks.filter(task => task.status === 'todo').length,
-      inProgressCount: project.tasks.filter(task => task.status === 'in_progress').length,
-      doneCount: project.tasks.filter(task => task.status === 'done').length,
+      ...formatProject(project),
       createdAt: project.createdAt,
       updatedAt: project.updatedAt
     }
@@ -111,10 +134,9 @@ const getMyProjects = async (userId: number, query: MeProjectQueryDto) => {
 }
 
 export default {
-  checkRole,
-  checkMember,
   createProject,
   getProject,
+  getProjectMembers,
   updateProject,
   deleteProject,
   sendInvitation,

--- a/src/modules/projects/projects.validator.ts
+++ b/src/modules/projects/projects.validator.ts
@@ -1,7 +1,7 @@
 import type { RequestHandler } from 'express';
 import forwardZodError from '#utils/zod';
-import { createProjectSchema, updateProjectSchema } from './dto/projects.dto';
-import { meProjectQuerySchema } from './dto/me-projects.dto';
+import { createProjectSchema, projectMemberQuerySchema, updateProjectSchema } from '#modules/projects/dto/projects.dto';
+import { meProjectQuerySchema } from '#modules/projects/dto/me-projects.dto';
 
 const validateCreateProject: RequestHandler = async (req, res, next) => {
   try {
@@ -21,6 +21,15 @@ const validateUpdateProject: RequestHandler = async (req, res, next) => {
   }
 }
 
+const validateProjectMemberQuery: RequestHandler = async (req, res, next) => {
+  try {
+    res.locals.projectMemberQuery = projectMemberQuerySchema.parse(req.query);
+    next();
+  } catch (err) {
+    forwardZodError(err, '프로젝트 멤버 조회', next);
+  }
+};
+
 const validateMeProjectQuery: RequestHandler = async (req, res, next) => {
   try {
     res.locals.meProjectQuery = meProjectQuerySchema.parse(req.query);
@@ -33,5 +42,6 @@ const validateMeProjectQuery: RequestHandler = async (req, res, next) => {
 export default {
   validateCreateProject,
   validateUpdateProject,
+  validateProjectMemberQuery,
   validateMeProjectQuery
 }

--- a/src/modules/projects/utils/mailUtils.ts
+++ b/src/modules/projects/utils/mailUtils.ts
@@ -1,5 +1,5 @@
 import ApiError from '#errors/ApiError';
-import smtpTransport from './smtp-transport';
+import smtpTransport from '#modules/projects/utils/smtp-transport';
 
 const sendMail = async (targetEmail: string, mailInfo: { subject: string, html: string }) => {
   const mailOptions = {

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -21,6 +21,7 @@ enum TaskStatus {
 enum ProjectRole {
   OWNER
   MEMBER
+  INVITED
 }
 
 enum SocialProvider {


### PR DESCRIPTION
# 주요 변경 사항
- 프로젝트 멤버 목록 조회 api를 추가했습니다.
- 초대 취소 api를 추가했습니다.
- 멤버 목록에 초대받은 사람도 표시되어야 하기 때문에 초대시 ProjectMember에 추가 하도록 변경했습니다.
- 그리고 초대를 받더라도 Invitation에서 사라지지 않고 `status`만 `accepted`로 설정하도록 변경했습니다.
- 멤버를 제외하거나 초대를 취소하는 경우에 ProjectMember와 Invitation에서 데이터가 삭제됩니다.

# 추가 변경 사항
- ProjectMember에 초대했지만 아직 수락하지 않은 상태를 나타내는 `INVITE`를 추가했습니다.
- import 경로를 절대 경로로 수정했습니다.

# 참고 사항
- Schema 변경으로 마이그레이션 필요합니다.