### PR TITLE
fix: await 누락된 validator 수정

### DIFF
--- a/src/modules/auth/auth.validator.ts
+++ b/src/modules/auth/auth.validator.ts
@@ -11,7 +11,7 @@ const validateAuthRegister: RequestHandler = async (req, res, next) => {
       password: req.body.password,
       profileImage: req.body.profileImage,
     };
-    authCreateSchema.parseAsync(parsedBody);
+    await authCreateSchema.parseAsync(parsedBody);
     next();
   } catch (err) {
     forwardZodError(err, '사용자 등록', next);
@@ -24,7 +24,7 @@ const validateAuthLogin: RequestHandler = async (req, res, next) => {
       email: req.body.email,
       password: req.body.password,
     };
-    loginSchema.parseAsync(parsedBody);
+    await loginSchema.parseAsync(parsedBody);
     next();
   } catch (err) {
     forwardZodError(err, '사용자 로그인', next);

--- a/src/modules/comments/comments.validator.ts
+++ b/src/modules/comments/comments.validator.ts
@@ -10,7 +10,7 @@ const validateCommentCreate: RequestHandler = async (req, res, next) => {
       authorId: req.user.id,
       content: req.body.content,
     };
-    commentCreateSchema.parseAsync(parsedBody);
+    await commentCreateSchema.parseAsync(parsedBody);
     next();
   } catch (err) {
     forwardZodError(err, '댓글 생성', next);
@@ -23,7 +23,7 @@ const validateCommentQuery: RequestHandler = async (req, res, next) => {
       page: req.query.page,
       limit: req.query.limit,
     };
-    commentQuerySchema.parseAsync(parsedQuery);
+    await commentQuerySchema.parseAsync(parsedQuery);
     next();
   } catch (err) {
     forwardZodError(err, '댓글 조회', next);
@@ -36,7 +36,7 @@ const validateCommentUpdate: RequestHandler = async (req, res, next) => {
       commentId: req.params.commentId,
       content: req.body.content,
     };
-    updateCommentSchema.parseAsync(parsedBody);
+    await updateCommentSchema.parseAsync(parsedBody);
     next();
   } catch (err) {
     forwardZodError(err, '댓글 수정', next);

--- a/src/modules/tasks/tasks.validator.ts
+++ b/src/modules/tasks/tasks.validator.ts
@@ -1,19 +1,10 @@
 import type { RequestHandler } from 'express';
 import ApiError from '#errors/ApiError';
 import forwardZodError from '#utils/zod';
-import { z } from 'zod';
 
 import { taskIdParamsSchema } from '#modules/tasks/dto/task-id.dto';
 import { meTasksQuerySchema } from '#modules/tasks/dto/me-tasks.dto';
 import { patchTaskBodySchema } from '#modules/tasks/dto/task.dto';
-
-/**
- * /tasks/:taskId/attachments
- * body: { urls: string[] }
- */
-const commitAttachmentsBodySchema = z.object({
-  urls: z.array(z.string().url()).min(1),
-});
 
 /* -------------------------------------------------------------------------- */
 /*                                  GET                                       */

--- a/src/modules/users/users.validator.ts
+++ b/src/modules/users/users.validator.ts
@@ -1,4 +1,3 @@
-// #modules/users/users.validator.ts
 import type { RequestHandler } from 'express';
 import forwardZodError from '#utils/zod';
 import { userUpdateSchema } from '#modules/users/dto/user.dto';


### PR DESCRIPTION
## 주요 변경 사항
- `await`이 누락되어 `errorHandler`에 도달하지 못하는 validator를 수정했습니다.
  - `await`이 누락되면, 관련 작업 완료 후 상태를 반환하기 전 `next()`가 실행되어 에러 핸들러가 정상 실행되지 않습니다.