### PR TITLE
fix: 메일 타임아웃 에러 수정

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -39,11 +39,10 @@ const nextConfig: NextConfig = {
 
   experimental: {
     serverActions: {
-      bodySizeLimit: '2mb',
+      bodySizeLimit: '1mb',
     },
   },
 
-  //서버 자꾸 죽여서 꺼버림
   eslint: {
     ignoreDuringBuilds: true,
   },

--- a/src/modules/projects/projects.service.ts
+++ b/src/modules/projects/projects.service.ts
@@ -1,3 +1,4 @@
+import { FRONT_ORIGIN } from '#config/env';
 import prisma from '#prisma/prisma';
 import ApiError from '#errors/ApiError';
 import projectRepo from '#modules/projects/projects.repo';
@@ -70,7 +71,7 @@ const updateProject = async (data: updateProjectDto, projectId: number, userId: 
 };
 
 const deleteProject = async (projectId: number, userId: number) => {
-  checkRole(projectId, userId);
+  await checkRole(projectId, userId);
   const deleteMailInfo = await projectRepo.findDeleteMailInfo(projectId);
   if (!deleteMailInfo) throw ApiError.notFound('프로젝트를 찾을 수 없습니다.');
   await projectRepo.remove(projectId);
@@ -84,37 +85,40 @@ const deleteProject = async (projectId: number, userId: number) => {
   };
   for (const member of deleteMailInfo.members) {
     const targetEmail = member.user.email;
-    await mailUtils.sendMail(targetEmail, mailInfo);
+    void mailUtils.sendMail(targetEmail, mailInfo).catch((e) => console.error('[deleteProject] mail send fail:', e));
   }
 };
 
 const sendInvitation = async (data: InvitationDto) => {
-  checkRole(data.inviter!, data.projectId);
+  await checkRole(data.projectId, data.inviter!);
 
-  await prisma.$transaction(async (tx) => {
-    const targetUserId = await projectRepo.findUserByEmail(data.targetEmail, tx);
-    if (!targetUserId) throw ApiError.notFound('초대할 사용자를 찾을 수 없습니다.');
-    const invitationToken = generateInvitationToken(data.projectId, targetUserId.id, data.targetEmail);
-    data.invitationToken = invitationToken;
+  const { invitationId, targetEmail, invitationToken } = await prisma.$transaction(async (tx) => {
+    const targetUser = await projectRepo.findUserByEmail(data.targetEmail, tx);
+    if (!targetUser) throw ApiError.notFound('초대할 사용자를 찾을 수 없습니다.');
 
-    await prisma.$transaction(async (tx) => {
-      const id = await projectRepo.createInvitation(data, targetUserId.id, tx);
-      const mailInfo = {
-        subject: '프로젝트에 초대합니다',
-        html: `
-          <h1> 프로젝트에 초대합니다. </h1>
-          <p>아래 링크를 클릭하여 프로젝트에 참여하세요:</p>
-          <a href="${process.env.FRONT_URL}/invitations/${id}?token=${data.invitationToken}">참여하기</a>
-        `,
-      };
-      await mailUtils.sendMail(data.targetEmail, mailInfo);
-    });
+    const token = generateInvitationToken(data.projectId, targetUser.id, data.targetEmail);
+
+    const id = await projectRepo.createInvitation({ ...data, invitationToken: token }, targetUser.id, tx);
+
+    return { invitationId: id, targetEmail: data.targetEmail, invitationToken: token };
   });
+
+  // 커밋 처리 후 메일 발송 -- 비동기로 처리하면 네트워크 시간 지연 문제로 단순 처리.
+  const mailInfo = {
+    subject: '프로젝트에 초대합니다',
+    html: `
+      <h1> 프로젝트에 초대합니다. </h1>
+      <p>아래 링크를 클릭하여 프로젝트에 참여하세요:</p>
+      <a href="${FRONT_ORIGIN}/invitations/${invitationId}?token=${encodeURIComponent(invitationToken)}">참여하기</a>
+    `,
+  };
+
+  void mailUtils.sendMail(targetEmail, mailInfo).catch((e) => console.error('[sendInvitation] mail send fail:', e));
 };
 
 const excludeMember = async (data: ExcludeMemberDto, userId: number) => {
   if (data.targetUserId < 1) throw ApiError.badRequest('유효하지 않은 사용자 ID입니다.');
-  checkRole(userId, data.projectId);
+  await checkRole(data.projectId, userId);
   await projectRepo.removeMember(data);
 };
 

--- a/src/modules/projects/utils/smtp-transport.ts
+++ b/src/modules/projects/utils/smtp-transport.ts
@@ -8,6 +8,12 @@ const smtpTransport = nodemailer.createTransport({
     user: process.env.SMTP_USER,
     pass: process.env.SMTP_PASS,
   },
+  pool: true, // 연결 재사용
+  maxConnections: 2, // 최대 연결 수
+  connectionTimeout: 10_000, // 타임아웃 10초
+  greetingTimeout: 10_000, // 10초 내에 서버 응답 없으면 실패
+  socketTimeout: 15_000, // 전체 통신 15초
+  tls: { servername: process.env.HOSTMAIL },
 });
 
 export default smtpTransport;


### PR DESCRIPTION
## 주요 변경 사항
- `project.service.ts`
  - 프로젝트 초대/삭제 시 메일 전송을 DB 트랜잭션 및 응답 경로에서 분리했습니다.
  - 메일 발송을 `fire-and-forget`으로 처리하여 Cloudflare 504 타임아웃 문제를 방지했습니다.
  - `checkRole` 호출부의 `await` 누락 및 인자를 보완했습니다.
- `smtp-transport.ts`
  - SMTP 풀링(pool) 옵션을 적용하고 connection/greeting/socket 타임아웃을 추가했습니다.
  - TLS servername 옵션을 지정했습니다.

## 추가 변경 사항
- `next.config.js/ts`
  - 일부 설정을 수정했습니다.